### PR TITLE
Refectored and removed the Clones "SerializableHelper" in the KeyEvents

### DIFF
--- a/robocode.api/src/main/java/robocode/KeyEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyEvent.java
@@ -41,4 +41,60 @@ public abstract class KeyEvent extends Event {
 		return source;
 	}
 
+	private static class SerializableHelper implements ISerializableHelper {
+
+		private static void serializeDetails(RbSerializer serializer, ByteBuffer buffer, java.awt.event.KeyEvent event) {
+			serializer.serialize(buffer, event.getKeyChar());
+			serializer.serialize(buffer, event.getKeyCode());
+			serializer.serialize(buffer, event.getKeyLocation());
+			serializer.serialize(buffer, event.getID());
+			serializer.serialize(buffer, event.getModifiersEx());
+			serializer.serialize(buffer, event.getWhen());
+		}
+
+		private static java.awt.event.KeyEvent deserializeDetails(ByteBuffer buffer) {
+			char keyChar = buffer.getChar();
+			int keyCode = buffer.getInt();
+			int keyLocation = buffer.getInt();
+			int id = buffer.getInt();
+			int modifiersEx = buffer.getInt();
+			long when = buffer.getLong();
+
+			return new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar, keyLocation);
+		}
+
+		public int sizeOf(RbSerializer serializer, Object object) {
+			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
+					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
+		}
+
+		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
+			if (object instanceof KeyTypedEvent) {
+				serializeDetails(serializer, buffer, ((KeyTypedEvent) object).getSourceEvent());
+			} else if (object instanceof KeyPressedEvent) {
+				serializeDetails(serializer, buffer, ((KeyPressedEvent) object).getSourceEvent());
+			} else if (object instanceof KeyReleasedEvent) {
+				serializeDetails(serializer, buffer, ((KeyReleasedEvent) object).getSourceEvent());
+			} else {
+				throw new IllegalArgumentException("Unsupported event type: " + object.getClass().getName());
+			}
+
+		}
+
+		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
+			java.awt.event.KeyEvent event = deserializeDetails(buffer);
+
+			// Determine the correct event type
+			switch (event.getID()) {
+				case java.awt.event.KeyEvent.KEY_TYPED:
+					return new KeyTypedEvent(event);
+				case java.awt.event.KeyEvent.KEY_PRESSED:
+					return new KeyPressedEvent(event);
+				case java.awt.event.KeyEvent.KEY_RELEASED:
+					return new KeyReleasedEvent(event);
+				default:
+					throw new IllegalArgumentException("Unknown key event type: " + event.getID());
+			}
+		}
+	}
 }

--- a/robocode.api/src/main/java/robocode/KeyPressedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyPressedEvent.java
@@ -78,37 +78,4 @@ public final class KeyPressedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyPressedEvent obj = (KeyPressedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyPressedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }

--- a/robocode.api/src/main/java/robocode/KeyReleasedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyReleasedEvent.java
@@ -78,37 +78,4 @@ public final class KeyReleasedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyReleasedEvent obj = (KeyReleasedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyReleasedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }

--- a/robocode.api/src/main/java/robocode/KeyTypedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyTypedEvent.java
@@ -78,37 +78,4 @@ public final class KeyTypedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyTypedEvent obj = (KeyTypedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyTypedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }


### PR DESCRIPTION
Type 2 code duplication in the SerializableHelper logic across multiple event classes (KeyTypedEvent, KeyPressedEvent, and KeyReleasedEvent). The redundant serialization and deserialization logic have been refactored into a shared utility class to improve maintainability and ensure consistency across all event types.

### Description
This Pull Request (PR) resolves software clones in the project by:

- removing the clones in file KeyTypedEvent, KeyPressedEvent, and KeyReleasedEvent 
- Updating KeyEvent file by adding a common SerializableHelper

### Changes Made
- robocode.api/src/main/java/robocode/KeyTypedEvent.java
- robocode.api/src/main/java/robocode/KeyPressedEvent.java
- robocode.api/src/main/java/robocode/KeyReleasedEvent.java
- robocode.api/src/main/java/robocode/KeyEvent.java

Issue : #1  
