### PR TITLE
removed the file name vulnerability by checking its canonical path

### DIFF
--- a/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
@@ -295,7 +295,18 @@ public class RobotFileSystemManager {
 				os = null;
 				try {
 					is = jarFile.getInputStream(jarEntry);
-					os = new FileOutputStream(new File(parent, filename));
+
+					// Secure path handling
+					File outputFile = new File(parent, filename);
+					String canonicalParentPath = parent.getCanonicalPath() + File.separator;
+					String canonicalOutputPath = outputFile.getCanonicalPath();
+
+					// Ensure the output file is within the parent directory
+					if (!canonicalOutputPath.startsWith(canonicalParentPath)) {
+						throw new IOException("Invalid entry: " + filename);
+					}
+
+					os = new FileOutputStream(outputFile);
 					copyStream(is, os);
 				} finally {
 					FileUtil.cleanupStream(is);


### PR DESCRIPTION
### Description

This Pull Request (PR) resolves software vulnerability in the project by:
- Validating the canonical path of archive entries before writing them to disk.
- Ensuring that all extracted files remain within the intended target directory (dataDir) to prevent path traversal attacks.

### Changes Made
robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java 

- Replaced unsafe ```new File(parent, filename)``` usage with secure path validation using ```getCanonicalPath()```.
- Implemented check to ensure the resolved output path starts with the canonical parent path.
- Added safeguards against partial path traversal by appending a trailing file separator.

Issue : #5 