### PR TITLE
Added path validation to file extraction in JarExtractor

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -68,6 +68,16 @@ public class JarExtractor {
 		File out = new File(dest, entry.getName());
 		File parentDirectory = new File(out.getParent());
 
+		String canonicalTopParentPath = dest.getCanonicalPath() + File.separator;
+		String canonicalParentPath = parentDirectory.getCanonicalPath();
+		String canonicalOutputPath = out.getCanonicalPath();
+
+		// Ensure the output file is within the top parent directory
+		if (!canonicalParentPath.startsWith(canonicalTopParentPath)
+				|| !canonicalOutputPath.startsWith(canonicalTopParentPath)) {
+			throw new IOException("Invalid entry: " + out);
+		}
+
 		if (!parentDirectory.exists() && !parentDirectory.mkdirs()) {
 			Logger.logError("Cannot create dir: " + parentDirectory);
 		}


### PR DESCRIPTION
Description

This Pull Request (PR) resolves software vulnerability in the project by:

    Validating the canonical path of archive entries before writing them to disk.
    Ensuring that all extracted files remain within the intended target directory (dest) to prevent path traversal attacks.

Changes Made

robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java

    Added secure path validation using getCanonicalPath().
    Implemented check to ensure the resolved output paths start with the canonical parent path.
    Added safeguards against partial path traversal by appending a trailing file separator.

Fixes issue #7
Add path validation to extractFile in JarExtractor to make sure no files outside the parent are affected